### PR TITLE
Fix source-code link typo

### DIFF
--- a/stopify-static-website/www/credits.html
+++ b/stopify-static-website/www/credits.html
@@ -63,7 +63,7 @@ layout: main
 <div class="row">
   <div class="col-md-5 col-md-offset-3">
     <h3 class="stopify-heading">Contact</h3>
-    <p class=" information">You can find the source code for Stopify on<a
+    <p class="information">You can find the source code for Stopify <a
     href="https://github.com/plasma-umass/stopify">here</a>. If you have
     any questions, feel free to email us or use
     <a href="https://github.com/plasma-umass/Stopify/issues">Github issues</a>.</p>


### PR DESCRIPTION
There was a small typo in the "Contact" section, this resolves it.